### PR TITLE
Make Add-Type open source files with FileAccess.Read explicitly (#7914)

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
@@ -965,7 +965,7 @@ namespace Microsoft.PowerShell.Commands
                 case FromLiteralPathParameterSetName:
                     foreach (string filePath in _paths)
                     {
-                        using (var sourceFile = new FileStream(filePath, FileMode.Open))
+                        using (var sourceFile = new FileStream(filePath, FileMode.Open, FileAccess.Read))
                         {
                             sourceText = SourceText.From(sourceFile);
                             syntaxTrees.Add(ParseSourceText(sourceText, parseOptions, path: filePath));


### PR DESCRIPTION
Fix #7914

Omitting the `FileAccess` attribute when constructing a `FileStream` with `FileMode.Open` makes the constructor default to `FileAccess.ReadWrite`, which is completely unecessary and inappropriate for Add-Type when compiling from source

## PR Summary

This PR ensures that `Add-Type` explicitly opens source code files with only `Read` access

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [X] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
