### PR TITLE
Track SequencePoint RunspaceId (broken)

### DIFF
--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -810,7 +810,7 @@ namespace System.Management.Automation.Language
 
             if (ProfilerEventSource.LogInstance.IsEnabled())
             {
-                ProfilerEventSource.LogInstance.SequencePoint(_scriptBlock.Id, pos);
+                ProfilerEventSource.LogInstance.SequencePoint(_scriptBlock.Id, _scriptBlock.SessionStateInternal.ExecutionContext.CurrentRunspace.InstanceId, pos);
             }
         }
 


### PR DESCRIPTION
ConditionalWeakTable only makes sense if we can tie the cache entry to
the lifetime of the source profiler. This commit replaces it with a
thread-safe ordered cache + concurrent metadata storage for compiled
script blocks.

That means Measure-Script can be parallelized - so to ensure it still
provides meaningful profiling data, the event source now includes
the runspace instance identifier in each SequencePoint event.

TODO: debug second-run caching issue

This now works the first time:

    PS C:\> 1..3 |Foreach-Object -Parallel {
    >>  $sb = {1..2 |ForEach-Object -Begin {Sleep 1} -Process { $_*2 }}
    >>  [pscustomobject]@{Events = Measure-Script -ScriptBlock $sb}
    >>} |Foreach-Object {
    >>  $_.Events |Format-Table Duration,Source -GroupBy RunspaceId
    >>}

       RunspaceId: 04e4e3ff-ab33-4537-b4de-ef3ce0739dfb

        Duration         Source
        --------         ------
        00:00:00.0013227 {
        00:00:00.0059372 1..2 |ForEach-Object -Begin {Sleep 1} -Proc...
        00:00:00.0000100 {
        00:00:01.1348230 Sleep 1
        00:00:00.0084265 }
        00:00:00.0030600 $_*2
        00:00:00.0000901 }
        00:00:00.0000037 {
        00:00:00.0000078 $_*2
        00:00:00.0004309 }
        00:00:00         }

        RunspaceId: 5c074123-5885-4d03-86b3-4ebcd786f6bc

        Duration         Source
        --------         ------
        00:00:00.0000082 {
        00:00:00.0036926 1..2 |ForEach-Object -Begin {Sleep 1} -Proc...
        00:00:00.0000080 {
        00:00:01.1361598 Sleep 1
        00:00:00.0084157 }
        00:00:00.0030854 $_*2
        00:00:00.0000610 }
        00:00:00.0000034 {
        00:00:00.0000075 $_*2
        00:00:00.0004724 }
        00:00:00         }

        RunspaceId: 65e96720-a108-4dc5-9e2e-0b56d2559a84

        Duration         Source
        --------         ------
        00:00:00.0014328 {
        00:00:00.0075100 1..2 |ForEach-Object -Begin {Sleep 1} -Proc...
        00:00:00.0000065 {
        00:00:01.1332892 Sleep 1
        00:00:00.0084158 }
        00:00:00.0000117 {
        00:00:00.0031304 $_*2
        00:00:00.0000839 }
        00:00:00.0000035 {
        00:00:00.0000078 $_*2
        00:00:00.0004490 }
        00:00:00         }

But subsequent runs return only a single set of events (instead of 3).
I suspect some scriptblock caching behavior is involved...
